### PR TITLE
Fixed prepareTypeName

### DIFF
--- a/src/prepare-type-name.js
+++ b/src/prepare-type-name.js
@@ -1,5 +1,5 @@
 const prepareTypeName = (name) => {
-    return name.replace(/Object/, '');
+    return new String(name).replace(/Object/, '');
 };
 
 const prepareImportsName = (name) => {


### PR DESCRIPTION
Argument may not be a string, then replace cannot be used